### PR TITLE
Prevent overlay window from taking focus when appearing

### DIFF
--- a/CurrencyAlert/Views/Windows/Overlay/CurrencyOverlay.cs
+++ b/CurrencyAlert/Views/Windows/Overlay/CurrencyOverlay.cs
@@ -28,7 +28,7 @@ public class CurrencyOverlay : Window {
     private List<TrackedCurrency> Currencies => CurrencyAlertSystem.Config is { RepositionMode: true } ? previewCurrencies : CurrencyAlertSystem.Config.Currencies;
     
     public CurrencyOverlay() : base("CurrencyAlert - Overlay Window") {
-        Flags |= ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoTitleBar;
+        Flags |= ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoFocusOnAppearing;
 
         ForceMainWindow = true;
     }


### PR DESCRIPTION
Simply adds the `ImGuiWindowFlags.NoFocusOnAppearing` flag to the overlay window. Without this flag, the overlay window appearing can cause an active input box to lose focus or cause a plugin like Wotsit to close due to loss of focus. Since this is just an overlay which doesn't actually need focus, I don't think there's any downside to setting this flag.