### PR TITLE
Track Orange Scrip instead of White by default

### DIFF
--- a/CurrencyAlert/CurrencyAlert.cs
+++ b/CurrencyAlert/CurrencyAlert.cs
@@ -105,17 +105,17 @@ public sealed class CurrencyAlertPlugin : IDalamudPlugin {
         }, // LimitedTomestone
 
         new TrackedCurrency {
-            Type = CurrencyType.Item, ItemId = 25199, Threshold = 3500, Enabled = true,
-        }, // WhiteCrafterScripts
-        new TrackedCurrency {
-            Type = CurrencyType.Item, ItemId = 25200, Threshold = 3500, Enabled = true,
-        }, // WhiteGathererScripts
-        new TrackedCurrency {
             Type = CurrencyType.Item, ItemId = 33913, Threshold = 3500, Enabled = true,
         }, // PurpleCrafterScripts
         new TrackedCurrency {
             Type = CurrencyType.Item, ItemId = 33914, Threshold = 3500, Enabled = true,
         }, // PurpleGathererScripts
+        new TrackedCurrency {
+            Type = CurrencyType.Item, ItemId = 41784, Threshold = 3500, Enabled = true,
+        }, // OrangeCrafterScripts
+        new TrackedCurrency {
+            Type = CurrencyType.Item, ItemId = 41785, Threshold = 3500, Enabled = true,
+        }, // OrangeGathererScripts
 
         new TrackedCurrency {
             Type = CurrencyType.Item, ItemId = 28063, Threshold = 7500, Enabled = true,


### PR DESCRIPTION
As of Dawntrail, White Scrip have been phased out and the new Scrip types are Purple and Orange, so the list should probably be updated so any new users get those two scrip types instead of the older ones.

Item IDs can be verified here if you want to double-check them:

- https://xivapi.com/item/41784?columns=ID,Name
- https://xivapi.com/item/41785?columns=ID,Name